### PR TITLE
Handle links with TA courses, and demarcate them

### DIFF
--- a/src/main/java/seedu/address/model/mod/ModuleCode.java
+++ b/src/main/java/seedu/address/model/mod/ModuleCode.java
@@ -20,7 +20,7 @@ public class ModuleCode {
      * All letters must be capitalized
      *
      */
-    public static final String VALIDATION_REGEX = "[A-Z]{2,4}\\d{4}[A-Z0-9]{0,5}";
+    public static final String VALIDATION_REGEX = "[A-Z]{2,4}\\d{4}[A-Z0-9]{0,5}(?: \\(TA\\))?";
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/person/LinkTest.java
+++ b/src/test/java/seedu/address/model/person/LinkTest.java
@@ -36,6 +36,7 @@ public class LinkTest {
         // invalid parts
         assertFalse(Link.isValidLink("www.nusmods.com/timetable/sem-2/share?CS2101")); // missing https
         // valid link
+        assertTrue(Link.isValidLink(Link.TA_EXAMPLE));
         assertTrue(Link.isValidLink("https://nusmods.com/timetable/sem-2/share?CS2101"));
         assertTrue(Link.isValidLink("https://nusmods.com/timetable/sem-1/share?"));
     }
@@ -52,6 +53,8 @@ public class LinkTest {
         codes =
             Link.extractCodes("https://nusmods.com/timetable/st-ii/share?AH3550=&CS1010E=TUT:05,SEC:1&MA3289=");
         assertTrue(codes.size() == 3);
+        codes = Link.extractCodes(Link.TA_EXAMPLE);
+        assertTrue(codes.contains("CS3230 (TA)"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #99 by changing the link extraction method to handle TAed courses. Then, those courses are appended with " (TA)" to distinguish them in the UI, which required changing the regex of a valid module code. 